### PR TITLE
add h0neytr4p

### DIFF
--- a/AttackMapServer.py
+++ b/AttackMapServer.py
@@ -17,7 +17,7 @@ from aiohttp import web
 # web_port = 1234
 redis_url = 'redis://map_redis:6379'
 web_port = 64299
-version = 'Attack Map Server 2.2.2'
+version = 'Attack Map Server 2.2.6'
 
 # Color Codes for Attack Map
 service_rgb = {

--- a/DataServer_v2.py
+++ b/DataServer_v2.py
@@ -14,7 +14,7 @@ es = Elasticsearch('http://elasticsearch:9200')
 redis_ip = 'map_redis'
 redis_instance = None
 redis_channel = 'attack-map-production'
-version = 'Data Server 2.2.2'
+version = 'Data Server 2.2.6'
 local_tz = get_localzone()
 output_text = os.getenv("CYBERPOT_ATTACKMAP_TEXT")
 
@@ -69,9 +69,9 @@ def get_honeypot_stats(timedelta):
                         "type.keyword": [
                             "Adbhoney", "Beelzebub", "Ciscoasa", "CitrixHoneypot", "ConPot",
                             "Cowrie", "Ddospot", "Dicompot", "Dionaea", "ElasticPot", 
-                            "Endlessh", "Galah", "Glutton", "Hellpot", "Heralding", 
-                            "Honeytrap", "Honeypots", "Log4pot", "Ipphoney", "Mailoney", 
-                            "Medpot", "Redishoneypot", "Sentrypeer", "Tanner", "Wordpot"
+                            "Endlessh", "Galah", "Glutton", "Go-pot", "H0neytr4p", "Hellpot", "Heralding", 
+                            "Honeyaml", "Honeytrap", "Honeypots", "Log4pot", "Ipphoney", "Mailoney", 
+                            "Medpot", "Miniprint", "Redishoneypot", "Sentrypeer", "Tanner", "Wordpot"
                         ]
                     }
                 },
@@ -119,9 +119,9 @@ def update_honeypot_data():
                         "query_string": {
                             "query": (
                                 "type:(Adbhoney OR Beelzebub OR Ciscoasa OR CitrixHoneypot OR ConPot OR Cowrie "
-                                "OR Ddospot OR Dicompot OR Dionaea OR ElasticPot OR Endlessh OR Galah OR Glutton "
-                                "OR Hellpot OR Heralding OR Honeypots OR Honeytrap OR Ipphoney OR Log4pot OR Mailoney "
-                                "OR Medpot OR Redishoneypot OR Sentrypeer OR Tanner OR Wordpot)"
+                                "OR Ddospot OR Dicompot OR Dionaea OR ElasticPot OR Endlessh OR Galah OR Glutton OR Go-pot OR H0neytr4p "
+                                "OR Hellpot OR Heralding OR Honeyaml OR Honeypots OR Honeytrap OR Ipphoney OR Log4pot OR Mailoney "
+                                "OR Medpot OR Miniprint OR Redishoneypot OR Sentrypeer OR Tanner OR Wordpot)"
                             )
                         }
                     }

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This geoip attack map visualizer was forked and adjusted to display CyberPot Hon
 
 ### Credits
 The original attack map was created by [Matthew Clark May](https://github.com/MatthewClarkMay/geoip-attack-map).<br>
+First CyberPot based fork was released by [Eddie4](https://github.com/eddie4/geoip-attack-map).
 
 ### Licenses / Copyright
 [Bootstrap](https://getbootstrap.com/docs/4.0/about/license/), [D3](https://github.com/d3/d3/blob/main/LICENSE), [Flagpack](https://github.com/Yummygum/flagpack-core/blob/main/LICENSE), [JQuery](https://jquery.org/license/), [Leaflet](https://github.com/Leaflet/Leaflet/blob/main/LICENSE), [OpenStreetMap](https://www.openstreetmap.org/copyright). 


### PR DESCRIPTION
Addresses issue: #

Changes proposed in this pull request:

- Change 1
- Change 2
- Change 3

## Summary by Sourcery

Add support for additional honeypot types and update version numbers. Enhance documentation by acknowledging contributions in the README.

New Features:
- Add support for new honeypot types 'Go-pot', 'H0neytr4p', 'Honeyaml', and 'Miniprint' in the honeypot statistics and data update functions.

Enhancements:
- Update version numbers for Data Server and Attack Map Server to 2.2.6.

Documentation:
- Add credit to Eddie4 for the first CyberPot based fork in the README.